### PR TITLE
fix NPE: method must not return null

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -3,6 +3,7 @@ package org.openhab.binding.zwave.internal;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -62,7 +63,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider { // , Con
     @Override
     public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
         logger.debug("getConfigDescriptions called");
-        return null;
+        return Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
The method getConfigDescriptions of the ConfigDescriptionProvider
interface states, that this function must not return null, but an empty
collection if there is no provider.

Signed-off-by: Markus Rathgeb maggu2810@gmail.com
