### PR TITLE
node id is a parameter and not a configuration

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/handler/ZWaveThingHandler.java
@@ -75,12 +75,17 @@ public class ZWaveThingHandler extends BaseThingHandler implements ZWaveEventLis
 
     @Override
     public void initialize() {
-        BigDecimal nodeParm = (BigDecimal) getConfig().get(ZWaveBindingConstants.PARAMETER_NODEID);
+        final String nodeParm = this.getThing().getProperties().get(ZWaveBindingConstants.PARAMETER_NODEID);
         if (nodeParm == null) {
             logger.debug("NodeID is not set in {}", this.getThing().getUID());
             return;
         }
-        nodeId = ((BigDecimal) getConfig().get(ZWaveBindingConstants.PARAMETER_NODEID)).intValue();
+        try {
+            nodeId = Integer.parseInt(nodeParm);
+        } catch (final NumberFormatException ex) {
+            logger.debug("NodeID ({}) cannot be parsed in {}", nodeParm, this.getThing().getUID());
+            return;
+        }
 
         // Until we get an update put the Thing into initialisation state
         updateStatus(ThingStatus.INITIALIZING);


### PR DESCRIPTION
The persistent inbox differs between configuration and properties of a thing now.

See:
https://github.com/eclipse/smarthome/blob/e2197aff1278925880fcc2c5ac91bb0e50ae2092/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java#L145

The nodeId is a thing property and not a configuration.
