### PR TITLE
use userdata directory provided by the framework

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -23,8 +23,6 @@ public class ZWaveBindingConstants {
 
     public static final String BINDING_ID = "zwave";
 
-    public static final String USERDATA_DIR_PROG_ARGUMENT = "smarthome.userdata";
-
     // Controllers
     public final static ThingTypeUID CONTROLLER_SERIAL = new ThingTypeUID(BINDING_ID, "serial_zstick");
 

--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/initialization/ZWaveNodeSerializer.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 
-import org.openhab.binding.zwave.ZWaveBindingConstants;
+import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.openhab.binding.zwave.internal.protocol.ZWaveDeviceClass;
 import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
 import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
@@ -41,7 +41,7 @@ public class ZWaveNodeSerializer {
 
     private static final Logger logger = LoggerFactory.getLogger(ZWaveNodeSerializer.class);
     private final XStream stream = new XStream(new StaxDriver());
-    private String folderName = "etc/zwave";
+    private final String folderName;
 
     /**
      * Constructor. Creates a new instance of the {@link ZWaveNodeSerializer} class.
@@ -49,10 +49,7 @@ public class ZWaveNodeSerializer {
     public ZWaveNodeSerializer() {
         logger.trace("Initializing ZWaveNodeSerializer.");
 
-        final String eshUserDataFolder = System.getProperty(ZWaveBindingConstants.USERDATA_DIR_PROG_ARGUMENT);
-        if (eshUserDataFolder != null) {
-            folderName = eshUserDataFolder + "/zwave";
-        }
+        folderName = ConfigConstants.getUserDataFolder() + "/zwave";
 
         final File folder = new File(folderName);
 
@@ -145,11 +142,12 @@ public class ZWaveNodeSerializer {
             } catch (IOException e) {
                 logger.error("NODE {}: Error serializing from file: {}", nodeId, e.getMessage());
             } finally {
-                if (reader != null)
+                if (reader != null) {
                     try {
                         reader.close();
                     } catch (IOException e) {
                     }
+                }
             }
             return null;
         }


### PR DESCRIPTION
There is already a framework function that returns the userdata
directory. This function is not only using a system property but also a
default value if the system property is not set. So there is no need for
a null check anymore.

We should use the function provided by the framework.
