### PR TITLE
getConfigDescriptions of a cfg desc prov must not return null

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/ZWaveConfigProvider.java
@@ -79,7 +79,7 @@ public class ZWaveConfigProvider implements ConfigDescriptionProvider, ConfigOpt
     @Override
     public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
         logger.debug("getConfigDescriptions called");
-        return null;
+        return Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
This has already been fixed in: d87dd2e56170ebe6d9aeabbc3896c75a96d22b0d
This fix has been reverted by: 796a241ac0d458b38420fec0afb3eb59402fbb72
