### PR TITLE
fix StackOverflowError for alarm command class

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/internal/protocol/commandclass/ZWaveAlarmSensorCommandClass.java
@@ -14,12 +14,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.openhab.binding.zwave.internal.protocol.SerialMessage;
-import org.openhab.binding.zwave.internal.protocol.ZWaveController;
-import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
-import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageClass;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessagePriority;
 import org.openhab.binding.zwave.internal.protocol.SerialMessage.SerialMessageType;
+import org.openhab.binding.zwave.internal.protocol.ZWaveController;
+import org.openhab.binding.zwave.internal.protocol.ZWaveEndpoint;
+import org.openhab.binding.zwave.internal.protocol.ZWaveNode;
 import org.openhab.binding.zwave.internal.protocol.event.ZWaveCommandClassValueEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -433,7 +433,7 @@ public class ZWaveAlarmSensorCommandClass extends ZWaveCommandClass
 
         @Override
         public Integer getValue() {
-            return getValue();
+            return (Integer) super.getValue();
         }
     }
 }


### PR DESCRIPTION
The function currently calls themselves.

``` text
Exception in thread "Thread-22" java.lang.StackOverflowError
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
    at org.openhab.binding.zwave.internal.protocol.commandclass.ZWaveAlarmSensorCommandClass$ZWaveAlarmSensorValueEvent.getValue(ZWaveAlarmSensorCommandClass.java:436)
```
