### PR TITLE
Zwave cc type

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
+++ b/addons/binding/org.openhab.binding.zwave/src/main/java/org/openhab/binding/zwave/ZWaveBindingConstants.java
@@ -43,5 +43,8 @@ public class ZWaveBindingConstants {
     public final static String CHANNEL_CFG_BINDING = "binding";
     public final static String CHANNEL_CFG_COMMANDCLASS = "commandClass";
 
+    public final static String CMDCLASS_ARG_ALARM_TYPE = "alarm_type";
+    public final static String CMDCLASS_ARG_SENSOR_TYPE = "sensor_type";
+
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES_UIDS = ImmutableSet.of(CONTROLLER_SERIAL);
 }


### PR DESCRIPTION
I am using a sensor that sends different sensor types using the multilevel sensor command class. The sensor type is currently not inspected, so the last value wins and will update all channels.
This PR will add inspection of "sensor_type" argument for multilevel sensor command group and "alarm_type" for alarm sensor command group.
If the argument is not specified, no filtering is done.
If it is specified, the event information must fit to the channel argument.

---

This PR is split into two commits, so you should have a look at it separately (easier to review).

The first one should not introduce any logical changes. It divides the event handling in separate functions so it should be easier to maintain (IMHO).

The second one adds handling for channel arguments.
