### PR TITLE
fix channel types

### DIFF
--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/aeonlabs_doorsensor_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/aeonlabs_doorsensor_00_000.xml
@@ -7,7 +7,7 @@
 		<label>Aeon Labs DoorSensor</label>
 		<description><![CDATA[Door/Window sensor<br><h1>Device Overview</h1><p>Brief description here</p><h1>Inclusion and Exclusion</h1><p>To include the device into the network...</p><p>To exclude the device from the network...</p>]]></description>
 		<channels>
-			<channel id="door-1" typeId="door">
+			<channel id="door-1" typeId="doorwindow">
 				<label>Door/Window State</label>
 				<properties>
 					<property name="binding:*:OnOffType">BASIC</property>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibarosystem_fgk101_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibarosystem_fgk101_00_000.xml
@@ -7,7 +7,7 @@
 		<label>Fibaro System FGK101</label>
 		<description><![CDATA[Door Opening Sensor]]></description>
 		<channels>
-			<channel id="door-1" typeId="door">
+			<channel id="door-1" typeId="doorwindow">
 				<properties>
                     <property name="binding:*:OnOffType">SENSOR_BINARY:1,BASIC:1</property>
 				</properties>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibarosystem_fgwpe_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/fibarosystem_fgwpe_00_000.xml
@@ -13,12 +13,12 @@
 					<property name="binding:*:OnOffType">SWITCH_BINARY,BASIC</property>
 				</properties>
 			</channel>
-			<channel id="power_watts-1" typeId="power_watts">
+			<channel id="power_watts-1" typeId="electric_watts">
 				<properties>
 					<property name="binding:*:DecimalType">METER;meterScale=E_W</property>
 				</properties>
 			</channel>
-			<channel id="power_energy-1" typeId="power_energy">
+			<channel id="power_energy-1" typeId="power_kwh">
 				<properties>
 					<property name="binding:*:DecimalType">METER;meterScale=E_KWh</property>
 				</properties>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/greenwave_np210_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/greenwave_np210_00_000.xml
@@ -7,13 +7,13 @@
 		<label>GreenWave NP210</label>
 		<description><![CDATA[Smart PowerNode<br><h1>Device Overview</h1><p>Brief description here</p><h1>Inclusion and Exclusion</h1><p>To include the device into the network...</p><p>To exclude the device from the network...</p>]]></description>
 		<channels>
-		    <channel id="power_watts-0" typeId="power_watts">
+		    <channel id="power_watts-0" typeId="electric_watts">
                 <label>Current Power (Total)</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-0" typeId="power_energy">
+            <channel id="power_energy-0" typeId="power_kwh">
                 <label>Energy Consumed (Total)</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_KWh</property>
@@ -26,13 +26,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:1,BASIC:1</property>
                 </properties>
             </channel>
-            <channel id="power_watts-1" typeId="power_watts">
+            <channel id="power_watts-1" typeId="electric_watts">
                 <label>Current Power 1</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:1;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-1" typeId="power_energy">
+            <channel id="power_energy-1" typeId="power_kwh">
                 <label>Energy Consumed 1</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:1;meterScale=E_KWh</property>
@@ -44,13 +44,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:2,BASIC:2</property>
                 </properties>
             </channel>
-            <channel id="power_watts-2" typeId="power_watts">
+            <channel id="power_watts-2" typeId="electric_watts">
                 <label>Current Power 2</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:2;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-2" typeId="power_energy">
+            <channel id="power_energy-2" typeId="power_kwh">
                 <label>Energy Consumed 2</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:2;meterScale=E_KWh</property>
@@ -62,13 +62,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:3,BASIC:3</property>
                 </properties>
             </channel>
-            <channel id="power_watts-3" typeId="power_watts">
+            <channel id="power_watts-3" typeId="electric_watts">
                 <label>Current Power 3</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:3;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-3" typeId="power_energy">
+            <channel id="power_energy-3" typeId="power_kwh">
                 <label>Energy Consumed 3</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:3;meterScale=E_KWh</property>
@@ -80,13 +80,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:4,BASIC:4</property>
                 </properties>
             </channel>
-            <channel id="power_watts-4" typeId="power_watts">
+            <channel id="power_watts-4" typeId="electric_watts">
                 <label>Current Power 4</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:4;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-4" typeId="power_energy">
+            <channel id="power_energy-4" typeId="power_kwh">
                 <label>Energy Consumed 4</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:4;meterScale=E_KWh</property>
@@ -98,13 +98,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:5,BASIC:5</property>
                 </properties>
             </channel>
-            <channel id="power_watts-5" typeId="power_watts">
+            <channel id="power_watts-5" typeId="electric_watts">
                 <label>Current Power 5</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:5;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-5" typeId="power_energy">
+            <channel id="power_energy-5" typeId="power_kwh">
                 <label>Energy Consumed 5</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:5;meterScale=E_KWh</property>
@@ -116,13 +116,13 @@
                     <property name="binding:*:OnOffType">SWITCH_BINARY:6,BASIC:6</property>
                 </properties>
             </channel>
-            <channel id="power_watts-6" typeId="power_watts">
+            <channel id="power_watts-6" typeId="electric_watts">
                 <label>Current Power 6</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:6;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_energy-6" typeId="power_energy">
+            <channel id="power_energy-6" typeId="power_kwh">
                 <label>Energy Consumed 6</label>
                 <properties>
                     <property name="binding:*:DecimalType">METER:6;meterScale=E_KWh</property>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/qubino_zmnhba_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/qubino_zmnhba_00_000.xml
@@ -21,12 +21,12 @@
 					<property name="binding:Command:OnOffType">SWITCH_BINARY:2,BASIC:2</property>
 				</properties>
 			</channel>
-			<channel id="power_watts-1" typeId="power_watts">
+			<channel id="power_watts-1" typeId="electric_watts">
 				<properties>
 					<property name="binding:*:DecimalType">METER;meterScale=E_W</property>
 				</properties>
 			</channel>
-			<channel id="power_energy-1" typeId="power_energy">
+			<channel id="power_energy-1" typeId="power_kwh">
 				<properties>
 					<property name="binding:*:DecimalType">METER;meterScale=E_KWh</property>
 				</properties>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/radiothermostatcompany_ct100_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/radiothermostatcompany_ct100_00_000.xml
@@ -25,7 +25,7 @@
                     <property name="binding:*:Number">SENSOR_MULTILEVEL:1;sensor_type=TEMPERATURE,setpoint_scale=1</property>
                 </properties>
             </channel>
-            <channel id="humidity-1" typeId="humidity">
+            <channel id="humidity-1" typeId="relhumidity">
                 <label>Current Temperature</label>
                 <properties>
                     <property name="binding:*:Number">SENSOR_MULTILEVEL:2;sensor_type=HUMIDITY</property>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/residentialcontrols_tbz48_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/residentialcontrols_tbz48_00_000.xml
@@ -25,7 +25,7 @@
                     <property name="binding:*:Number">SENSOR_MULTILEVEL:1;sensor_type=TEMPERATURE,setpoint_scale=1</property>
                 </properties>
             </channel>
-            <channel id="humidity-1" typeId="humidity">
+            <channel id="humidity-1" typeId="relhumidity">
                 <label>Current Temperature</label>
                 <properties>
                     <property name="binding:*:Number">SENSOR_MULTILEVEL:2;sensor_type=HUMIDITY</property>

--- a/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/wenzhoutkbcontrolsystem_tz88_00_000.xml
+++ b/addons/binding/org.openhab.binding.zwave/ESH-INF/thing/wenzhoutkbcontrolsystem_tz88_00_000.xml
@@ -48,27 +48,27 @@ within 1.5 seconds.
 					<property name="binding:Command:OnOffType">SWITCH_BINARY,BASIC</property>
 				</properties>
 			</channel>
-            <channel id="power_watts-1" typeId="power_watts">
+            <channel id="power_watts-1" typeId="electric_watts">
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_W</property>
                 </properties>
             </channel>
-            <channel id="power_current-1" typeId="power_current">
+            <channel id="power_current-1" typeId="electric_current">
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_A</property>
                 </properties>
             </channel>
-            <channel id="power_voltage-1" typeId="power_voltage">
+            <channel id="power_voltage-1" typeId="electric_voltage">
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_V</property>
                 </properties>
             </channel>
-            <channel id="power_powerfactor-1" typeId="power_powerfactor">
+            <channel id="power_powerfactor-1" typeId="electric_powerfactor">
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_Power_Factor</property>
                 </properties>
             </channel>
-            <channel id="power_energy-1" typeId="power_energy">
+            <channel id="power_energy-1" typeId="power_kwh">
                 <properties>
                     <property name="binding:*:DecimalType">METER;meterScale=E_KWh</property>
                 </properties>


### PR DESCRIPTION
The commit 79d6441a502403f6fd53056d91e47216c3be33fd changes some channel
types that are still used by things.
The current thing-types REST API will fail caused by a NPE. The NPE is
caused because the channel type of a channel could not be found.
